### PR TITLE
fix: resolve failing unit tests

### DIFF
--- a/src/pylogtrail/client/handlers.py
+++ b/src/pylogtrail/client/handlers.py
@@ -57,18 +57,13 @@ class PyLogTrailHTTPHandler(logging.handlers.HTTPHandler):
             "funcName": record.funcName,
         }
 
-        print(json.dumps(data, indent=2))
-
         # Add any additional attributes from the record
         for key, value in record.__dict__.items():
             if key not in data and not key.startswith("_"):
-                print(key, type(value))
                 data[key] = value
 
         # Add metadata to the JSON payload
         data.update(self.metadata)
-
-        print(json.dumps(data, indent=2))
 
         return data
 

--- a/src/pylogtrail/server/download_api.py
+++ b/src/pylogtrail/server/download_api.py
@@ -34,50 +34,56 @@ def parse_timeframe(timeframe: str) -> Optional[datetime]:
     if not timeframe:
         return None
         
-    timeframe = timeframe.lower().strip()
+    timeframe = timeframe.strip()
     now = datetime.now(timezone.utc)
     
     try:
         # Try parsing as ISO format first
         if 'T' in timeframe or '-' in timeframe:
-            dt = datetime.fromisoformat(timeframe.replace('Z', '+00:00'))
+            # Handle different ISO format variations
+            iso_string = timeframe
+            if iso_string.endswith('Z'):
+                iso_string = iso_string[:-1] + '+00:00'
+            
+            dt = datetime.fromisoformat(iso_string)
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
             return dt
     except (ValueError, TypeError):
         pass
     
-    # Parse relative time formats
-    if timeframe.endswith(('d', 'day', 'days')):
+    # Parse relative time formats (convert to lowercase for pattern matching)
+    timeframe_lower = timeframe.lower()
+    if timeframe_lower.endswith(('d', 'day', 'days')):
         # Extract number of days
-        num_str = timeframe.rstrip('days').rstrip('day').rstrip('d')
+        num_str = timeframe_lower.rstrip('days').rstrip('day').rstrip('d')
         try:
             days = int(num_str)
             return now - timedelta(days=days)
         except ValueError:
             pass
     
-    elif timeframe.endswith(('w', 'week', 'weeks')):
+    elif timeframe_lower.endswith(('w', 'week', 'weeks')):
         # Extract number of weeks
-        num_str = timeframe.rstrip('weeks').rstrip('week').rstrip('w')
+        num_str = timeframe_lower.rstrip('weeks').rstrip('week').rstrip('w')
         try:
             weeks = int(num_str)
             return now - timedelta(weeks=weeks)
         except ValueError:
             pass
     
-    elif timeframe.endswith(('m', 'month', 'months')):
+    elif timeframe_lower.endswith(('m', 'month', 'months')):
         # Extract number of months (approximate as 30 days each)
-        num_str = timeframe.rstrip('months').rstrip('month').rstrip('m')
+        num_str = timeframe_lower.rstrip('months').rstrip('month').rstrip('m')
         try:
             months = int(num_str)
             return now - timedelta(days=months * 30)
         except ValueError:
             pass
     
-    elif timeframe.endswith(('h', 'hour', 'hours')):
+    elif timeframe_lower.endswith(('h', 'hour', 'hours')):
         # Extract number of hours
-        num_str = timeframe.rstrip('hours').rstrip('hour').rstrip('h')
+        num_str = timeframe_lower.rstrip('hours').rstrip('hour').rstrip('h')
         try:
             hours = int(num_str)
             return now - timedelta(hours=hours)

--- a/test_retention.py
+++ b/test_retention.py
@@ -52,10 +52,15 @@ def test_retention_manager():
 def test_api_endpoints():
     """Test that API endpoints can be imported"""
     try:
+        from flask import Flask
         from pylogtrail.server.retention_api import retention_bp
         
+        # Create a temporary Flask app and register the blueprint to access routes
+        app = Flask(__name__)
+        app.register_blueprint(retention_bp)
+        
         # Check that the blueprint has the expected routes
-        rules = [rule.rule for rule in retention_bp.url_map.iter_rules()]
+        rules = [rule.rule for rule in app.url_map.iter_rules()]
         expected_routes = ['/api/retention/settings', '/api/retention/cleanup', '/api/retention/preview']
         
         for route in expected_routes:


### PR DESCRIPTION
Fixes #11

This PR fixes the failing unit tests by:
- Removing debug print statements from handlers.py that interfere with tests
- Fixing blueprint URL map access by creating Flask app in test_retention.py
- Ensuring unit tests can run without output interference or import errors

Generated with [Claude Code](https://claude.ai/code)